### PR TITLE
Fixing nginx proxy to set right authority and fixing DNS namespace

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "gateway_image" {
-  default = "josmo/sample-proxy:lum"
+  default = "usernames/lum-proxy:appmesh"
 }
 variable "node_1_image" {
   default = "karthequian/helloworld:latest"
@@ -8,7 +8,7 @@ variable "node_2_image" {
   default = "tutum/hello-world"
 }
 variable "namespace" {
-  default = "luminary.local"
+  default = "lum.local"
 }
 variable "mesh_name" {
   default = "luminary-mesh"


### PR DESCRIPTION
*Creating this PR for your testing*

- Basically your nginx proxy in your gateway was forwarding the ingress IP as the Host header to Envoy, since Enovy routes based on host header, the request was failing. 

```
# cat etc/nginx/nginx.conf
worker_processes 1;

events { worker_connections 1024; }

http {

    sendfile on;

    server {
        listen 80;

        location / {
            proxy_pass         http://api.lum.local:80;
            proxy_http_version 1.1;
            proxy_redirect     off;
            proxy_set_header   Host api.lum.local;  # this line has been changed
            proxy_set_header   X-Real-IP $remote_addr;
            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header   X-Forwarded-Host $server_name;
        }
    }
}
```
Since there was no `Dockerfile` here, I have created pushed a new image to my repo.

- I have also went ahead and fixed the DNS namespace to match the one in the `nginx` configs